### PR TITLE
Introduce inter-iframe messaging using reflux store WindowActions

### DIFF
--- a/WRIO-InternetOS/js/actions/WindowActions.js
+++ b/WRIO-InternetOS/js/actions/WindowActions.js
@@ -1,0 +1,13 @@
+/**
+ * Created by michbil on 26.01.16.
+ */
+
+var Reflux = require('reflux');
+
+module.exports = Reflux.createActions([
+    'titterMessage',
+    'loginMessage',
+    'chessMessage',
+    'plusMessage',
+    'webGoldMessage'
+]);

--- a/WRIO-InternetOS/js/components/CreateDomCenter.js
+++ b/WRIO-InternetOS/js/components/CreateDomCenter.js
@@ -1,26 +1,27 @@
 import {getServiceUrl,getDomain} from '../servicelocator.js';
+import React from 'react';
+import Reflux from 'reflux';
+import Login from '../../../widgets/Login.jsx';
+import Chess from '../../../widgets/Chess.jsx';
+import Details from '../../../widgets/Details.jsx';
+import {importUrl} from '../global';
+import {theme} from '../global';
+import CreateBreadcrumb from './CreateBreadcrumb';
+import CreateTitter from '../../../widgets/titter.jsx';
+import Center from './Center';
+import StoreLd from '../store/center';
+import classNames from 'classnames';
+import ActionMenu from '../../../widgets/Plus/actions/menu';
+import StoreMenu from '../../../widgets/Plus/stores/menu';
+import UrlMixin from '../mixins/UrlMixin';
+import {Alert} from 'react-bootstrap';
+import CreateTransactions from '../../../widgets/transactions.jsx';
+import CenterActions from '../actions/center';
+import PlusStore from '../../../widgets/Plus/stores/jsonld';
+import WindowActions from '../actions/WindowActions.js';
+import WindowActionStore from '../store/WindowMessage.js';
 
 var domain = getDomain();
-
-var React = require('react'),
-    Reflux = require('reflux'),
-    Login = require('../../../widgets/Login.jsx'),
-    Chess = require('../../../widgets/Chess.jsx'),
-    Details = require('../../../widgets/Details.jsx'),
-    importUrl = require('../global').importUrl,
-    theme = require('../global').theme,
-    CreateBreadcrumb = require('./CreateBreadcrumb'),
-    CreateTitter = require('../../../widgets/titter.jsx'),
-    Center = require('./Center'),
-    StoreLd = require('../store/center'),
-    classNames = require('classnames'),
-    ActionMenu = require('../../../widgets/Plus/actions/menu'),
-    StoreMenu = require('../../../widgets/Plus/stores/menu'),
-    UrlMixin = require('../mixins/UrlMixin'),
-    Alert = require('react-bootstrap').Alert,
-    CreateTransactions = require('../../../widgets/transactions.jsx'),
-    CenterActions = require('../actions/center'),
-    PlusStore = require('../../../widgets/Plus/stores/jsonld');
 
 class CreateDomCenter extends React.Component {
 
@@ -134,19 +135,14 @@ class CreateDomCenter extends React.Component {
         });
         this.listenStoreMenuSidebar = StoreMenu.listenTo(ActionMenu.showSidebar, this.onShowSidebar);
 
-        window.addEventListener('message', (e) => {
-
-            var httpChecker = new RegExp('^(http|https)://login.' + domain, 'i');
-            if (httpChecker.test(e.origin)) {
-                let jsmsg = JSON.parse(e.data);
-                if (jsmsg.profile) {
-                    this.userId(jsmsg.profile.id);
-                }
-                PlusStore.hideAlertWarning(this.state.userId, this.hideAlertWarning);
-                PlusStore.hideAlertWelcome(this.state.userId, this.hideAlertWelcome);
+        WindowActions.loginMessage.listen((msg)=> {
+            if (msg.profile) {
+                this.userId(msg.profile.id);
             }
-
+            PlusStore.hideAlertWarning(this.state.userId, this.hideAlertWarning);
+            PlusStore.hideAlertWelcome(this.state.userId, this.hideAlertWelcome);
         });
+
     }
 
     onStateChange(state) {

--- a/WRIO-InternetOS/js/store/WindowMessage.js
+++ b/WRIO-InternetOS/js/store/WindowMessage.js
@@ -1,0 +1,47 @@
+/**
+ * Created by michbil on 26.01.16.
+ */
+
+import Reflux from 'reflux';
+import WindowActions from '../actions/WindowActions.js';
+import {getServiceUrl,getDomain} from '../servicelocator.js';
+
+var domain = getDomain();
+
+module.exports = Reflux.createStore({
+
+    init() {
+
+        window.addEventListener('message', function (e) {
+            console.log("Dispatched a message");
+            var message = e.data;
+            try {
+                var msg = JSON.parse(message);
+            } catch (e) {
+                console.log("Error parsing the message");
+            }
+
+            var httpChecker = new RegExp('^(http|https)://titter.' + domain, 'i');
+            if (httpChecker.test(e.origin)) {
+                WindowActions.titterMessage.trigger(msg);
+            }
+
+            httpChecker = new RegExp('^(http|https)://login.' + domain, 'i');
+            if (httpChecker.test(e.origin)) {
+                WindowActions.loginMessage.trigger(msg);
+            }
+            httpChecker = new RegExp('^(http|https)://webgold.' + domain, 'i');
+            if (httpChecker.test(e.origin)) {
+                WindowActions.webGoldMessage.trigger(msg);
+            }
+            httpChecker = new RegExp('^(http|https)://chess.' + domain, 'i');
+            if (httpChecker.test(e.origin)) {
+                WindowActions.chessMessage.trigger(msg);
+            }
+
+        });
+
+    }
+
+});
+

--- a/widgets/Chess.jsx
+++ b/widgets/Chess.jsx
@@ -17,7 +17,6 @@ export default class Chess extends React.Component {
     }
 
     requestChess(jsmsg) {
-        // TODO: is that safe? can any sensible information be got by thrird party?
         request.get(getServiceUrl('chess') + '/data?uuid=' + this.props.uuid + '&wrid=' + jsmsg.id, (err, res) => {
             if (res) {
                 res = res.body || {};

--- a/widgets/Chess.jsx
+++ b/widgets/Chess.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {getServiceUrl,getDomain} from '../WRIO-InternetOS/js/servicelocator.js';
 import Login from './Login.jsx';
 import request from 'superagent';
+import WindowActions from '../WRIO-InternetOS/js/actions/WindowActions.js';
 
 var domain = getDomain();
 
@@ -15,13 +16,30 @@ export default class Chess extends React.Component {
         };
     }
 
-    componentWillMount() {
-        window.addEventListener('message', (e) => {
-            var message = e.data;
-            var httpChecker = new RegExp('^(http|https)://login.' + domain, 'i');
-            if (httpChecker.test(e.origin)) {
-                var jsmsg = JSON.parse(message);
+    requestChess(jsmsg) {
+        // TODO: is that safe? can any sensible information be got by thrird party?
+        request.get(getServiceUrl('chess') + '/data?uuid=' + this.props.uuid + '&wrid=' + jsmsg.id, (err, res) => {
+            if (res) {
+                res = res.body || {};
+                this.setState({
+                    profile: jsmsg,
+                    user: res.user,
+                    invite: res.invite,
+                    alien: res.alien,
+                    expired: res.expired,
+                    footer: res.alien ? "This link is for the player @" + res.user.username : (res.expired ? "Link Expired" : "...please wait")
+                });
+            } else {
+                this.setState({
+                    disabled: false,
+                    footer: 'Authorisation error. Please try again later.'
+                });
+            }
+        });
+    }
 
+    componentWillMount() {
+        WindowActions.loginMessage.listen((jsmsg) => {
                 if (jsmsg.login == "success") {
                     location.reload();
                 }
@@ -34,27 +52,9 @@ export default class Chess extends React.Component {
                             footer: ''
                         });
                     } else {
-                        request.get(getServiceUrl('chess') + '/data?uuid=' + this.props.uuid + '&wrid=' + jsmsg.id, (err, res) => {
-                            if (res) {
-                                res = res.body || {};
-                                this.setState({
-                                    profile: jsmsg,
-                                    user: res.user,
-                                    invite: res.invite,
-                                    alien: res.alien,
-                                    expired: res.expired,
-                                    footer: res.alien ? "This link is for the player @" + res.user.username : (res.expired ? "Link Expired" : "...please wait")
-                                });
-                            } else {
-                                this.setState({
-                                    disabled: false,
-                                    footer: 'Authorisation error. Please try again later.'
-                                });
-                            }
-                        });
+                        this.requestChess(jsmsg);
                     }
                 }
-            }
         });
     }
 

--- a/widgets/Login.jsx
+++ b/widgets/Login.jsx
@@ -3,6 +3,7 @@ import Actions from '../WRIO-InternetOS/js/actions/center';
 import Details from'./Details.jsx';
 import moment from 'moment';
 import {getServiceUrl,getDomain} from '../WRIO-InternetOS/js/servicelocator.js';
+import WindowActions from '../WRIO-InternetOS/js/actions/WindowActions.js';
 
 var domain = getDomain();
 
@@ -42,50 +43,44 @@ class Login extends React.Component{
 
         var that = this;
 
-        window.addEventListener('message', function (e) {
-            var message = e.data;
-            var httpChecker = new RegExp('^(http|https)://login.' + domain, 'i');
-            if (httpChecker.test(e.origin)) {
-                var jsmsg = JSON.parse(message);
+        WindowActions.loginMessage.listen((jsmsg) => {
+            if (jsmsg.login == "success") {
+                location.reload();
+            }
 
-                if (jsmsg.login == "success") {
-                    location.reload();
-                }
-
-                if (jsmsg.profile) {
-                    jsmsg = jsmsg.profile;
-                    Actions.gotWrioID(jsmsg.id);
-                    if (jsmsg.temporary) {
-                        that.setState({
-                            title: {
-                                text: "Logged as I'm Anonymous ",
-                                label: 'WRIO',
-                                link: {
-                                    url: jsmsg.url
-                                }
-                            },
-                            upgrade: {
-                                text: "Upgrade guest account for free",
-                                label: jsmsg.days + ' days left',
-                                visible: true
+            if (jsmsg.profile) {
+                var profile = jsmsg.profile;
+                Actions.gotWrioID(profile.id);
+                if (profile.temporary) {
+                    that.setState({
+                        title: {
+                            text: "Logged as I'm Anonymous ",
+                            label: 'WRIO',
+                            link: {
+                                url: profile.url
                             }
-                        });
-                    } else {
-                        that.setState({
-                            title: {
-                                text: "Logged in as " + jsmsg.name,
-                                label: 'WRIO',
-                                link: {
-                                    url: jsmsg.url
-                                }
-                            },
-                            upgrade: {
-                                text: "Lock up or switch user",
-                                label: jsmsg.days + ' days left',
-                                visible: false
+                        },
+                        upgrade: {
+                            text: "Upgrade guest account for free",
+                            label: profile.days + ' days left',
+                            visible: true
+                        }
+                    });
+                } else {
+                    that.setState({
+                        title: {
+                            text: "Logged in as " + profile.name,
+                            label: 'WRIO',
+                            link: {
+                                url: profile.url
                             }
-                        });
-                    }
+                        },
+                        upgrade: {
+                            text: "Lock up or switch user",
+                            label: profile.days + ' days left',
+                            visible: false
+                        }
+                    });
                 }
             }
         });

--- a/widgets/Plus/P.js
+++ b/widgets/Plus/P.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import {getServiceUrl,getDomain} from '../../WRIO-InternetOS/js/servicelocator.js';
-
+import WindowActions from '../../WRIO-InternetOS/js/actions/WindowActions.js';
 var domain = getDomain();
 
 class P extends React.Component{
@@ -21,18 +21,11 @@ class P extends React.Component{
 
     }
     componentDidMount () {
-        window.addEventListener('message', function (e) {
-
-            var httpChecker = new RegExp('^(http|https)://login.' + domain, 'i');
-            if (httpChecker.test(e.origin)) {
-                var jsmsg = JSON.parse(e.data);
-                if (jsmsg.profile) {
-                    this.userId(jsmsg.profile.id);
-                }
-
+       WindowActions.loginMessage.listen((jsmsg) => {
+            if (jsmsg.profile) {
+                this.userId(jsmsg.profile.id);
             }
-
-        }.bind(this));
+        });
     }
 
     gotoUrl(){

--- a/widgets/titter.jsx
+++ b/widgets/titter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {getServiceUrl,getDomain} from '../WRIO-InternetOS/js/servicelocator.js';
+import WindowActions from '../WRIO-InternetOS/js/actions/WindowActions.js';
 
 var domain = getDomain();
 
@@ -218,17 +219,10 @@ var CreateTitter = React.createClass({
 
         document.getElementById('titteriframe').style.height = '240px';
 
-        window.addEventListener('message', function (e) {
-
-                var message = e.data;
-                var httpChecker = new RegExp('^(http|https)://titter.' + domain, 'i');
-                if (httpChecker.test(e.origin)) {
-                    var jsmsg = JSON.parse(message);
-
-                    if (jsmsg.titterHeight) {
-                        document.getElementById('titteriframe').style.height = jsmsg.titterHeight+'px';
-                    }
-                };
+        WindowActions.titterMessage.listen((msg)=> {
+            if (msg.titterHeight) {
+                document.getElementById('titteriframe').style.height = msg.titterHeight+'px';
+            }
         });
 
         var commentTitle = '<ul class="breadcrumb twitter"><li class="active">Comments</li><li class="pull-right"></li></ul>';

--- a/widgets/transactions.jsx
+++ b/widgets/transactions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {getServiceUrl,getDomain} from '../WRIO-InternetOS/js/servicelocator.js';
-
+import WindowActions from '../WRIO-InternetOS/js/actions/WindowActions.js';
 var domain = getDomain();
 
 var CreateTransactions = React.createClass({
@@ -16,18 +16,10 @@ var CreateTransactions = React.createClass({
     createTransactionsWidget: function() {
         var twheight = 10000;
         document.getElementById('transactionsiframe').style.height = '240px';
-
-        window.addEventListener('message', function (e) {
-
-                var message = e.data;
-                var httpChecker = new RegExp('^(http|https)://webgold.' + domain, 'i');
-                if (httpChecker.test(e.origin)) {
-                    var jsmsg = JSON.parse(message);
-
-                    if (jsmsg.transactionsHeight) {
-                        document.getElementById('transactionsiframe').style.height = jsmsg.transactionsHeight+'px';
-                    }
-                };
+        WindowActions.webGoldMessage.listen((msg)=> {
+            if (msg.transactionsHeight) {
+                document.getElementById('transactionsiframe').style.height = msg.transactionsHeight+'px';
+            }
         });
 
     },


### PR DESCRIPTION
@balthazzar для решения проблемы хождения сообщений между iframe, а также для упрощения кода создал отдельный Store /store/WindowMessage.js, в который приходят все сообщения из iframe. В дальнейшем этот store посылает сообщения /actions/WindowActions 

```
module.exports = Reflux.createActions([
    'titterMessage',
    'loginMessage',
    'chessMessage',
    'plusMessage',
    'webGoldMessage'
]);
```

в зависимости от того кому предназначено сообщение.  Теперь вместо `window.addeventlistener('message',...` нужно делать `WindowActions.loginMessage.listen(` и.т.д.

@balthazzar  Сделал мелкий рефакторинг твоего кода, проверь чтобы ничего не сломал случайно.
