### PR TITLE
Creating a list using the first comment #496

### DIFF
--- a/src/CoreEditor/actions/publishActions.js
+++ b/src/CoreEditor/actions/publishActions.js
@@ -5,6 +5,8 @@ import { formatAuthor } from '../utils/url.js';
 import DraftExporter from '../DraftExporter';
 import ListExporter from '../ListExporter';
 
+const fakeWidgetId = '875721502196465664';
+
 export const DESC_CHANGED = 'DESC_CHANGED';
 export const FILENAME_CHANGED = 'FILENAME_CHANGED';
 export const HEADER_CHANGED = 'HEADER_CHANGED';
@@ -52,13 +54,13 @@ export function publishDocument(saveSource: string) {
         coverHtml,
         coverFileName,
       } = state.publish;
-      if (commentsEnabled && commentId === '') {
-        commentId = (await getWidgetID(saveUrl)).text;
-        console.log('Get widget id succeded', commentId);
-      }
-      if (!commentsEnabled) {
-        commentId = '';
-      }
+
+      commentId = commentsEnabled
+        ? commentId === ''
+          ? fakeWidgetId
+          : commentId
+        : '';
+
       document.setCommentID(commentId);
       document.setAbout(description);
 

--- a/src/CoreEditor/components/PostSettings.js
+++ b/src/CoreEditor/components/PostSettings.js
@@ -84,14 +84,15 @@ export default class PostSettings extends React.Component {
                   {this.props.busy ? loading : <span className="glyphicon glyphicon-open with_text" />}
                   Publish
                 </Button>
-                <DropdownButton
-                  bsStyle="success narrow-dropdown"
-                  title=""
-                  id="bg-vertical-dropdown-1"
-                 
-                >
-                  <MenuItem eventKey="1"  onClick={() => this.props.onPublish('saveas')}>SaveAs</MenuItem>
-                </DropdownButton>
+                {!this.props.commentsEnabled &&
+                  <DropdownButton
+                    bsStyle="success narrow-dropdown"
+                    title=""
+                    id="bg-vertical-dropdown-1"
+                  >
+                    <MenuItem eventKey="1"  onClick={() => this.props.onPublish('saveas')}>SaveAs</MenuItem>
+                  </DropdownButton>
+                }
               </ButtonGroup>
             </div>
           </div>


### PR DESCRIPTION
https://github.com/webRunes/Pinger-WRIO-App/issues/496

Save as dropdown should be hidden if comments enabled.
Do not require twitter widget timeline id for new articles.
New articles setted with fake id '875721502196465664'. This id will be saved at 'comment' field at JSON-LD