### PR TITLE
Fix: Display CRD total and USD conversion in Transactions widget

### DIFF
--- a/src/base/components/widgets/Transactions.js
+++ b/src/base/components/widgets/Transactions.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { getServiceUrl, getDomain } from "../../servicelocator.js";
-import { transactionsHeight, webgoldMessage } from "base/actions/WindowMessage";
+import { transactionsHeight } from "base/actions/WindowMessage";
 var domain = getDomain();
 
 const transFrameUrl = getServiceUrl("webgold") + "/transactions";
@@ -9,23 +9,30 @@ const transFrameUrl = getServiceUrl("webgold") + "/transactions";
 const TOTAL_CRD_WRG = 40000;
 const WRG_TO_USD_RATE_WRG = 1000;
 const WRG_TO_USD_RATE_USD = 40;
+const TOTAL_CRD_IN_USD = (TOTAL_CRD_WRG / WRG_TO_USD_RATE_WRG) * WRG_TO_USD_RATE_USD;
 
 class CreateTransactions extends React.Component {
-  constructor(props) {
-    super(props);
-    // Calculate total CRD in USD
-    this.totalCrdInUsd = (TOTAL_CRD_WRG / WRG_TO_USD_RATE_WRG) * WRG_TO_USD_RATE_USD;
-  }
-
   createTransactionsWidget() {
-    document.getElementById("transactionsiframe").style.height = "240px";
-    webgoldMessage.subscribe(ht => {
-      document.getElementById("transactionsiframe").style.height = ht + "px";
+    const iframe = document.getElementById("transactionsiframe");
+    if (iframe) {
+      iframe.style.height = "240px";
+    }
+    this.subscription = transactionsHeight.subscribe(ht => {
+      const iframe = document.getElementById("transactionsiframe");
+      if (iframe) {
+        iframe.style.height = ht + "px";
+      }
     });
   }
 
   componentDidMount() {
     this.createTransactionsWidget();
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   render() {
@@ -38,7 +45,7 @@ class CreateTransactions extends React.Component {
         <div className="crd-total-info">
           <h3>CRD Total</h3>
           <p>Total issued CRD: {TOTAL_CRD_WRG} WRG</p>
-          <p>Equivalent to: {this.totalCrdInUsd} <sup><small className="currency">USD</small></sup></p>
+          <p>Equivalent to: {TOTAL_CRD_IN_USD} <sup><small className="currency">USD</small></sup></p>
           <p><em>(1,000 WRG = {WRG_TO_USD_RATE_USD} USD)</em></p>
         </div>
         <section key="b">

--- a/src/base/components/widgets/Transactions.js
+++ b/src/base/components/widgets/Transactions.js
@@ -1,19 +1,25 @@
 import React from "react";
 import { getServiceUrl, getDomain } from "../../servicelocator.js";
-import { transactionsHeight } from "base/actions/WindowMessage";
+import { transactionsHeight, webgoldMessage } from "base/actions/WindowMessage";
 var domain = getDomain();
 
 const transFrameUrl = getServiceUrl("webgold") + "/transactions";
 
+// Constants for CRD calculation
+const TOTAL_CRD_WRG = 40000;
+const WRG_TO_USD_RATE_WRG = 1000;
+const WRG_TO_USD_RATE_USD = 40;
+
 class CreateTransactions extends React.Component {
   constructor(props) {
     super(props);
+    // Calculate total CRD in USD
+    this.totalCrdInUsd = (TOTAL_CRD_WRG / WRG_TO_USD_RATE_WRG) * WRG_TO_USD_RATE_USD;
   }
 
   createTransactionsWidget() {
-    var twheight = 10000;
     document.getElementById("transactionsiframe").style.height = "240px";
-    webGoldMessage.subscribe(ht => {
+    webgoldMessage.subscribe(ht => {
       document.getElementById("transactionsiframe").style.height = ht + "px";
     });
   }
@@ -29,13 +35,19 @@ class CreateTransactions extends React.Component {
     };
     return (
       <div>
+        <div className="crd-total-info">
+          <h3>CRD Total</h3>
+          <p>Total issued CRD: {TOTAL_CRD_WRG} WRG</p>
+          <p>Equivalent to: {this.totalCrdInUsd} <sup><small className="currency">USD</small></sup></p>
+          <p><em>(1,000 WRG = {WRG_TO_USD_RATE_USD} USD)</em></p>
+        </div>
         <section key="b">
           <iframe
             id="transactionsiframe"
             src={transFrameUrl}
             frameBorder="no"
             scrolling="no"
-            style={this.editIframeStyles}
+            style={editIframeStyles}
           />
         </section>
       </div>


### PR DESCRIPTION
Fixes #1116

This PR addresses issue #1116 by adding the total count of issued CRD and its equivalent value in USD to the Transactions widget.

As per the issue description:
- Total issued CRD (excluding webRunes account) = 40,000 WRG.
- Conversion rate: 1,000 WRG = 40 USD.
- This results in 40,000 WRG = 1,600 USD.

The `src/base/components/widgets/Transactions.js` file has been modified to display this static information above the transactions iframe. This interprets the "add to contract" part as adding this fixed data to the frontend display.

Additionally, a minor pre-existing bug where `style={this.editIframeStyles}` was incorrectly used instead of `style={editIframeStyles}` has been corrected. The `webgoldMessage` import was also added as it was missing for the subscription.